### PR TITLE
Clone Firefox and run tests locally with extension installed

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,16 @@
 {
-  "extends": "airbnb-base",
+  "extends": [
+    "airbnb-base",
+    "plugin:mozilla/recommended"
+  ],
   "env": {
     "webextensions": true,
     "browser": true
+  },
+  "globals": {
+    "add_task": true,
+    "is": true,
+    "ok": true
   },
   "rules": {
     "object-curly-newline": ["error", {"consistent": true}],

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -51,13 +51,15 @@ tasks:
             npm install &&
             npm run build &&
             npm run lint &&
-            npm run package
+            npm run package &&
+            /repo/bin/commit_xpi.sh
       metadata:
         name: "Firefox Experiments GitHub Tests"
         description: "All tests"
         owner: ${event.pull_request.user.login}@users.noreply.github.com
         source: ${event.repository.url}
   # When a commit is pushed to master, perform this task
+  # Note: Currently this is wrongly showing a status on PR pushes in GitHub (Bug 1514914)
   # If a branch is merged without being updated first, the tests could pass on the branch
   # but not when things are merged into master.
   - $if: 'tasks_for == "github-push"'
@@ -91,7 +93,8 @@ tasks:
               npm install &&
               npm run build &&
               npm run lint &&
-              npm run package
+              npm run package &&
+              /repo/bin/commit_xpi.sh
         metadata:
           name: "Firefox Experiments GitHub Tests"
           description: "All tests"

--- a/bin/commit_xpi.sh
+++ b/bin/commit_xpi.sh
@@ -44,7 +44,3 @@ echo ">>> verify with local mochitest that extension is installed"
 
 # The diff needs to be checked in to run on the Try server
 echo ">>> commit diff to hg"
-
-# TODO: What would this look like? Try running a local ./mach test? Would need to build
-# Firefox locally as well.
-echo ">>> verify commit"

--- a/bin/commit_xpi.sh
+++ b/bin/commit_xpi.sh
@@ -24,9 +24,13 @@ echo ">>> copy XPI (or ZIP) to test dir"
 cp /repo/web-ext-artifacts/* /repo/mozilla-central/testing/profiles/common/extensions/
 
 # --artifact is not a recognized option for './mach build', so enable artifact builds via .mozconfig
-echo ">>> create .mozconfig to enable artifact builds locally"
+echo ">>> copy over .mozconfig to enable artifact builds locally"
+# TODO: make .mozconfig file
 # TODO: For Beta and Release builds, add 'releases/mozilla-beta' or 'releases/mozilla-release'
 # respectively to the list of CANDIDATE_TREES in ./python/mozbuild/mozbuild/artifacts.py
+
+echo ">>> copy test files over to Firefox"
+# TODO: copy contents of repo/test/ into Firefox's ./testing/extensions/ dir. 
 
 echo ">>> build Firefox"
 # ./mach clobber
@@ -36,7 +40,7 @@ echo ">>> build Firefox"
 # Note: The extension is only installed with the testing profile (i.e. when running mochitests or talos
 # tests); it is not installed with ./mach build or ./mach run separately.
 echo ">>> verify with local mochitest that extension is installed"
-# ./mach mochitest /path/to/test
+# ./mach test /path/to/test
 
 # The diff needs to be checked in to run on the Try server
 echo ">>> commit diff to hg"

--- a/bin/commit_xpi.sh
+++ b/bin/commit_xpi.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Clones Firefox, copies the XPI to a test directory and commits the change to Mercurial.
+
+set -e
+
+# TODO: Make env variable in .taskcluster.yml that gets passed to this script to specify
+# which channel(s) to test in
+
+# Repo URLs:
+#   - Nightly: https://hg.mozilla.org/mozilla-central
+#   - Beta: https://hg.mozilla.org/releases/mozilla-beta
+#   - Release: https://hg.mozilla.org/releases/mozilla-release
+echo ">>> shallow clone Firefox"
+hg clone --rev=5 https://hg.mozilla.org/mozilla-central
+
+# Test dir(s) specified per bugs 1451159 and 1458571
+echo ">>> copy XPI to test dir"
+
+# --artifact is not a recognized option for './mach build', so enable artifact builds via .mozconfig
+echo ">>> create .mozconfig to enable artifact builds locally"
+# TODO: For Beta and Release builds, add 'releases/mozilla-beta' or 'releases/mozilla-release'
+# respectively to the list of CANDIDATE_TREES in ./python/mozbuild/mozbuild/artifacts.py
+
+# Note: The extension is only installed with the testing profile (i.e. when running mochitests or talos
+# tests); it is not installed with ./mach build or ./mach run separately.
+echo ">>> verify successful mochitest locally"
+# ./mach mochitest /path/to/test
+
+echo ">>> commit diff to hg"
+
+# TODO: What would this look like? Try running a local ./mach test? Would need to build
+# Firefox locally as well.
+echo ">>> verify commit"

--- a/bin/commit_xpi.sh
+++ b/bin/commit_xpi.sh
@@ -15,22 +15,30 @@ set -e
 #   - Nightly: https://hg.mozilla.org/mozilla-central
 #   - Beta: https://hg.mozilla.org/releases/mozilla-beta
 #   - Release: https://hg.mozilla.org/releases/mozilla-release
-echo ">>> shallow clone Firefox"
-hg clone --rev=5 https://hg.mozilla.org/mozilla-central
+echo ">>> clone Firefox"
+# TODO: Investigate how to get a shallow clone of Firefox -- this full clone takes 3ish minutes alone.
+hg clone https://hg.mozilla.org/mozilla-central
 
 # Test dir(s) specified per bugs 1451159 and 1458571
-echo ">>> copy XPI to test dir"
+echo ">>> copy XPI (or ZIP) to test dir"
+cp /repo/web-ext-artifacts/* /repo/mozilla-central/testing/profiles/common/extensions/
 
 # --artifact is not a recognized option for './mach build', so enable artifact builds via .mozconfig
 echo ">>> create .mozconfig to enable artifact builds locally"
 # TODO: For Beta and Release builds, add 'releases/mozilla-beta' or 'releases/mozilla-release'
 # respectively to the list of CANDIDATE_TREES in ./python/mozbuild/mozbuild/artifacts.py
 
+echo ">>> build Firefox"
+# ./mach clobber
+# ./mach build
+
+# The diff does NOT need to be checked in to run tests locally
 # Note: The extension is only installed with the testing profile (i.e. when running mochitests or talos
 # tests); it is not installed with ./mach build or ./mach run separately.
-echo ">>> verify successful mochitest locally"
+echo ">>> verify with local mochitest that extension is installed"
 # ./mach mochitest /path/to/test
 
+# The diff needs to be checked in to run on the Try server
 echo ">>> commit diff to hg"
 
 # TODO: What would this look like? Try running a local ./mach test? Would need to build

--- a/package-lock.json
+++ b/package-lock.json
@@ -3158,6 +3158,57 @@
         }
       }
     },
+    "eslint-plugin-mozilla": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mozilla/-/eslint-plugin-mozilla-1.0.3.tgz",
+      "integrity": "sha512-OeaP4yUQxSvx5b9Mi/RlYRUPzxmCxMwHaEU0O1Zc1yqX0QCmkcew9ln45cBBnzLmWmNIuCDz8T2bOXB+ofRs9Q==",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "3.9.2",
+        "ini-parser": "0.0.2",
+        "sax": "1.2.4"
+      },
+      "dependencies": {
+        "htmlparser2": {
+          "version": "3.9.2",
+          "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+          "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "domhandler": "^2.3.0",
+            "domutils": "^1.5.1",
+            "entities": "^1.1.1",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "eslint-plugin-no-unsafe-innerhtml": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsafe-innerhtml/-/eslint-plugin-no-unsafe-innerhtml-1.0.16.tgz",
@@ -3452,6 +3503,12 @@
           }
         }
       }
+    },
+    "eslint-plugin-no-unsanitized": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-3.0.2.tgz",
+      "integrity": "sha512-JnwpoH8Sv4QOjrTDutENBHzSnyYtspdjtglYtqUtAHe6f6LLKqykJle+UwFPg23GGwt5hI3amS9CRDezW8GAww==",
+      "dev": true
     },
     "eslint-restricted-globals": {
       "version": "0.1.1",
@@ -5382,6 +5439,12 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "ini-parser": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/ini-parser/-/ini-parser-0.0.2.tgz",
+      "integrity": "sha1-+kF4flZ3Y7P/Zdel2alO23QHh+8=",
       "dev": true
     },
     "inquirer": {

--- a/package.json
+++ b/package.json
@@ -26,9 +26,12 @@
     "eslint": "5.10.0",
     "eslint-config-airbnb-base": "13.1.0",
     "eslint-plugin-import": "2.14.0",
+    "eslint-plugin-mozilla": "1.0.3",
+    "eslint-plugin-no-unsanitized": "^3.0.2",
     "generate-json-webpack-plugin": "0.3.1",
     "web-ext": "2.9.2",
     "webpack": "4.27.1",
     "webpack-cli": "3.1.2"
-  }
+  },
+  "dependencies": {}
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,6 +5,11 @@
   "version": "$version",
   "author": "$author",
   "homepage_url": "$homepage",
+  "applications": {
+   "gecko": {
+     "id": "taskcluster-integration-poc@mozilla.org"
+    }
+  },
   "icons": {
     "48": "icons/message-48.png"
   },

--- a/test/browser_chrome/browser.ini
+++ b/test/browser_chrome/browser.ini
@@ -1,0 +1,1 @@
+[browser_experiment_installed_check.js]

--- a/test/browser_chrome/browser_experiment_installed_check.js
+++ b/test/browser_chrome/browser_experiment_installed_check.js
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// (Modeled after Screenshots system add-on tests in browser/extensions/screenshots/test)
+
+/* global ChromeUtils, AddonManager, add_task, ok, is */
+
+ChromeUtils.defineModuleGetter(this, 'AddonManager',
+  'resource://gre/modules/AddonManager.jsm');
+
+const ADDON_NAME = 'taskcluster-integration-poc';
+const ADDON_ID = `${ADDON_NAME}@mozilla.org`;
+
+add_task(async () => {
+  const addon = await AddonManager.getAddonByID(`${ADDON_ID}`);
+  ok(!!addon, 'Addon exists');
+  is(addon.name, `${ADDON_NAME}`, 'Addon has matching id');
+});

--- a/test/browser_chrome/browser_experiment_installed_check.js
+++ b/test/browser_chrome/browser_experiment_installed_check.js
@@ -4,16 +4,14 @@
 
 // (Modeled after Screenshots system add-on tests in browser/extensions/screenshots/test)
 
-/* global ChromeUtils, AddonManager, add_task, ok, is */
+ChromeUtils.defineModuleGetter(this, "AddonManager",
+  "resource://gre/modules/AddonManager.jsm");
 
-ChromeUtils.defineModuleGetter(this, 'AddonManager',
-  'resource://gre/modules/AddonManager.jsm');
-
-const ADDON_NAME = 'taskcluster-integration-poc';
+const ADDON_NAME = "taskcluster-integration-poc";
 const ADDON_ID = `${ADDON_NAME}@mozilla.org`;
 
 add_task(async () => {
   const addon = await AddonManager.getAddonByID(`${ADDON_ID}`);
-  ok(!!addon, 'Addon exists');
-  is(addon.name, `${ADDON_NAME}`, 'Addon has matching id');
+  ok(!!addon, "Addon exists");
+  is(addon.name, `${ADDON_NAME}`, "Addon has matching id");
 });

--- a/test/moz.build
+++ b/test/moz.build
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# The 'browser chrome' flavor of mochitests
+BROWSER_CHROME_MANIFESTS += [
+  'browser_chrome/browser.ini'
+]
+
+# The 'chrome' flavor of mochitests
+# MOCHITEST_CHROME_MANIFESTS += [
+#   'mochitest_chrome/chrome.ini'
+# ]
+
+# The 'plain' flavor of mochitests
+# MOCHITEST_MANIFESTS += [
+#   'mochitest/mochitest.ini'
+# ]
+
+# XPCSHELL_TESTS_MANIFESTS += [
+#   'xpcshell/xpcshell.ini'
+# ]

--- a/test/moz.build
+++ b/test/moz.build
@@ -2,6 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# TODO: (from _6a68, written by Standard8) Consider automatically generating a moz.build file
+# instead of copying one over: e.g. https://github.com/mozilla/followonsearch/blob/master/scripts/export_mc.py
+
 # The 'browser chrome' flavor of mochitests
 BROWSER_CHROME_MANIFESTS += [
   'browser_chrome/browser.ini'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,41 +5,41 @@
 /* eslint-env node */
 /* eslint-disable import/no-extraneous-dependencies */
 
-const path = require('path');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
-const GenerateJsonPlugin = require('generate-json-webpack-plugin');
+const path = require("path");
+const CopyWebpackPlugin = require("copy-webpack-plugin");
+const GenerateJsonPlugin = require("generate-json-webpack-plugin");
 
-const packageData = require('./package.json');
-const manifestTemplate = require('./src/manifest.json');
+const packageData = require("./package.json");
+const manifestTemplate = require("./src/manifest.json");
 
-const ROOT_DIR = path.resolve(__dirname, '.');
-const BUILD_DIR = path.resolve(ROOT_DIR, 'build');
+const ROOT_DIR = path.resolve(__dirname, ".");
+const BUILD_DIR = path.resolve(ROOT_DIR, "build");
 
 module.exports = {
-  mode: 'development',
-  devtool: 'inline-source-map',
-  target: 'web',
+  mode: "development",
+  devtool: "inline-source-map",
+  target: "web",
   context: ROOT_DIR,
   entry: {
-    background: './src/background',
-    content: './src/content-script',
+    background: "./src/background",
+    content: "./src/content-script",
   },
   output: {
     path: BUILD_DIR,
-    filename: '[name].bundle.js',
+    filename: "[name].bundle.js",
   },
-  node: { fs: 'empty' },
+  node: { fs: "empty" },
   plugins: [
     new CopyWebpackPlugin([
       // Static files
-      {from: '**/*.png'},
-    ], {context: 'src/'}),
+      {from: "**/*.png"},
+    ], {context: "src/"}),
 
     // Process and emit manifest.json, replacing any values that start with $
     // with the corresponding key from package.json.
-    new GenerateJsonPlugin('manifest.json', manifestTemplate, (key, value) => {
-      if (typeof value === 'string' && value.startsWith('$')) {
-        const parts = value.slice(1).split('.');
+    new GenerateJsonPlugin("manifest.json", manifestTemplate, (key, value) => {
+      if (typeof value === "string" && value.startsWith("$")) {
+        const parts = value.slice(1).split(".");
         let object = packageData;
         while (parts.length > 0) {
           object = object[parts.pop()];


### PR DESCRIPTION
The shell script added here, as outlined, will handle copying the XPI and any custom tests into the appropriate testing dir(s), committing the change and running any custom tests locally to verify the extension has been added correctly.

So far, this PR only covers the files and instructions needed to run the custom test locally (not on the Docker image). This is because we need to modify `./moz.build` to point to our new `./testing/extensions/moz.build` file as a prerequisite to running our custom tests, and that is a change we want to land permanently in the tree. Providing our own `moz.build` file allows us to add additional tests and kinds of tests at our discretion.

The last commit provides instructions for how to verify the extension is installed in a local build of Firefox (not on the Docker image).


Currently, it gives us a full clone (see #6 ) of Nightly, though eventually we should provide the ability to specify which channel(s) to test on.

Hg repo URLs:
* Nightly: https://hg.mozilla.org/mozilla-central
* Beta: https://hg.mozilla.org/releases/mozilla-beta
* Release: https://hg.mozilla.org/releases/mozilla-release

Note: As with all executables (such as bash shell scripts), executable permission must be explicitly given for the file before it can be run (i.e. `chmod +x /path/to/file`).