### PR TITLE
Get Taskcluster secret within task execution and push extension to Try server

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -14,10 +14,12 @@ tasks:
         git_url: ${event.repository.url}
         url: ${event.repository.url}
         ref: ${event.after}
+        owner: ${event.pusher.name}
       else:
         git_url: ${event.pull_request.head.repo.git_url}
         url: ${event.pull_request.head.repo.url}
         ref: ${event.pull_request.head.sha}
+        owner: ${event.pull_request.user.login}
   in:
     $let:
       taskRef:
@@ -61,6 +63,8 @@ tasks:
             # The name of the secret to fetch from Taskcluster's Secrets API
             SSHKEY_SECRET_NAME: "github.com/biancadanforth/taskcluster-integration-poc/ssh-key"
             SHELL: "/bin/bash"
+            USERNAME: ${repo.owner}
+            USER_EMAIL: ${repo.owner}@users.noreply.github.com
           command: # The command to run within the Docker image
             - "/bin/bash"
             # '--login' (executes user's profile commands), '-c' (executes commands from a string)
@@ -82,10 +86,10 @@ tasks:
         metadata:
           name: "Firefox Experiments GitHub Tests"
           description: "All tests"
-          owner: ${event.pull_request.user.login}@users.noreply.github.com
-          source: ${event.repository.url}
+          owner: ${repo.owner}@users.noreply.github.com
+          source: ${repo.url}
     in:
-      # When a commit is pushed to master or a PR is opened, reopened or synchronized
+      # When a PR is created or modified, perform this task
       - $if: 'tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "synchronize"]'
         then: {$eval: taskRef}
       # When a commit is pushed to master, perform this task

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -37,7 +37,7 @@ tasks:
           # Service provided by the worker that lets the task make authenticated TC requests within
           # the scope(s) of a particular task.
           taskclusterProxy: true
-        maxRunTime: 600 # 10 minutes
+        maxRunTime: 1200 # 20 minutes
         image: "node:10" # The Docker image to pull
         # The worker will automatically upload any artifacts upon task completion
         artifacts: # syntax depends on the workerType
@@ -52,6 +52,7 @@ tasks:
           DEBUG: "* -eslint*"
           # The name of the secret to fetch from Taskcluster's Secrets API
           SSHKEY_SECRET_NAME: "github.com/biancadanforth/taskcluster-integration-poc/ssh-key"
+          SHELL: "/bin/bash"
         command: # The command to run within the Docker image
           - "/bin/bash"
           - "-lc" # '--login' (executes user's profile commands), '-c' (executes commands from a string)

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -66,7 +66,10 @@ tasks:
             npm run package &&
             /repo/bin/commit_xpi.sh &&
             /repo/bin/configure_ssh.sh &&
-            node /repo/bin/get_secret.js
+            node /repo/bin/get_secret.js &&
+            cd mozilla-central &&
+            /repo/bin/configure_hg.sh &&
+            ./mach try -p linux64 -u all -t none --artifact
       metadata:
         name: "Firefox Experiments GitHub Tests"
         description: "All tests"

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -3,12 +3,12 @@
 #  - https://github.com/taskcluster/taskcluster-github/blob/master/docs/taskcluster-yml-v1.md
 version: 1
 policy:
-  # Run these tasks for qualifying GH events for collaborators only to avoid just anyone having access
-  # to my Taskcluster secret(s)
+  # Run these tasks for qualifying GH events for collaborators only to avoid just anyone having
+  # access to my Taskcluster secret(s)
   pullRequests: collaborators
 tasks:
-  # When a PR is opened, reopened or synchronized, perform this task
-  # This covers additional commits to an existing open PR
+  # When a PR is opened, reopened or synchronized, perform this task; this covers additional
+  # commits to an existing open PR
   - $if: 'tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "synchronize"]'
     then:
       # TC creates a task group with tasks in it; each task has an ID. TC will provide a link
@@ -27,35 +27,34 @@ tasks:
       # resources within which the task should be executed. Pools may use different
       # EC2 instance types, AMIs (Amazon Machine Images), etc.
       # Generally, github-worker is a variant of docker-worker in TC docs
-      workerType: github-worker # TC's generic worker for any github projects; can do Try server pushes
-      # A scope is a permission to perform a particular action. A task has a set of
-      # scopes that determine what the task can do. These scopes are validated by the worker.
+      workerType: github-worker # TC's generic worker for any github projects
+      # A scope is a permission to perform a particular action. A task has a set of scopes
+      # that determine what the task can do. These scopes are validated by the worker.
       scopes:
         - secrets:get:github.com/biancadanforth/taskcluster-integration-poc/ssh-key
-      payload: # The format of a task's payload property is specific to the worker that will execute it
+      payload: # format depends on workerType
         features:
-          # Service provided by the worker that lets the task make authenticated TC requests within
-          # the scope(s) of a particular task.
+          # Service provided by the worker that lets the task make authenticated TC
+          # requests within the scope(s) of a particular task.
           taskclusterProxy: true
         maxRunTime: 1200 # 20 minutes
         image: "node:10" # The Docker image to pull
         # The worker will automatically upload any artifacts upon task completion
-        artifacts: # syntax depends on the workerType
+        artifacts: # format depends on the workerType
           public/web-ext-artifacts:
             # contentType is not a valid key for workerType github-worker
             expires: {$fromNow: '14 days'}
             path: /repo/web-ext-artifacts
             type: directory
         env: # Environment variables to declare in the shell
-          # Say you have debug statements in library code; a DEBUG variable with a
-          # value of * will log all levels of debug statements
-          DEBUG: "* -eslint*"
+          DEBUG: "* -eslint*" # Log levels for debug statements in library code; * means all
           # The name of the secret to fetch from Taskcluster's Secrets API
           SSHKEY_SECRET_NAME: "github.com/biancadanforth/taskcluster-integration-poc/ssh-key"
           SHELL: "/bin/bash"
         command: # The command to run within the Docker image
           - "/bin/bash"
-          - "-lc" # '--login' (executes user's profile commands), '-c' (executes commands from a string)
+          # '--login' (executes user's profile commands), '-c' (executes commands from a string)
+          - "-lc"
           - >-
             git clone ${event.pull_request.head.repo.git_url} repo &&
             cd repo &&
@@ -64,11 +63,11 @@ tasks:
             npm run build &&
             npm run lint &&
             npm run package &&
+            /repo/bin/configure_hg.sh &&
             /repo/bin/commit_xpi.sh &&
             /repo/bin/configure_ssh.sh &&
             node /repo/bin/get_secret.js &&
             cd mozilla-central &&
-            /repo/bin/configure_hg.sh &&
             ./mach try -p linux64 -u all -t none --artifact
       metadata:
         name: "Firefox Experiments GitHub Tests"
@@ -76,9 +75,7 @@ tasks:
         owner: ${event.pull_request.user.login}@users.noreply.github.com
         source: ${event.repository.url}
   # When a commit is pushed to master, perform this task
-  # Note: Currently this is wrongly showing a status on PR pushes in GitHub (Bug 1514914)
-  # If a branch is merged without being updated first, the tests could pass on the branch
-  # but not when things are merged into master.
+  # Note: Currently this is wrongly showing a status in GitHub PRs (Bug 1514914)
   - $if: 'tasks_for == "github-push"'
     then:
       $if: 'event.ref == "refs/heads/master"'

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -3,7 +3,9 @@
 #  - https://github.com/taskcluster/taskcluster-github/blob/master/docs/taskcluster-yml-v1.md
 version: 1
 policy:
-  pullRequests: public # Run these tasks for qualifying GH events from any one in the repo
+  # Run these tasks for qualifying GH events for collaborators only to avoid just anyone having access
+  # to my Taskcluster secret(s)
+  pullRequests: collaborators
 tasks:
   # When a PR is opened, reopened or synchronized, perform this task
   # This covers additional commits to an existing open PR
@@ -28,9 +30,15 @@ tasks:
       workerType: github-worker # TC's generic worker for any github projects; can do Try server pushes
       # A scope is a permission to perform a particular action. A task has a set of
       # scopes that determine what the task can do. These scopes are validated by the worker.
+      scopes:
+        - secrets:get:github.com/biancadanforth/taskcluster-integration-poc/ssh-key
       payload: # The format of a task's payload property is specific to the worker that will execute it
+        features:
+          # Service provided by the worker that lets the task make authenticated TC requests within
+          # the scope(s) of a particular task.
+          taskclusterProxy: true
         maxRunTime: 600 # 10 minutes
-        image: "node:8" # The Docker image to pull
+        image: "node:10" # The Docker image to pull
         # The worker will automatically upload any artifacts upon task completion
         artifacts: # syntax depends on the workerType
           public/web-ext-artifacts:
@@ -39,9 +47,12 @@ tasks:
             path: /repo/web-ext-artifacts
             type: directory
         env: # Environment variables to declare in the shell
-          DEBUG: "* -eslint*" # Say you have debug statements in library code; a DEBUG variable with a
+          # Say you have debug statements in library code; a DEBUG variable with a
           # value of * will log all levels of debug statements
-        command: # The command to run within that Docker image
+          DEBUG: "* -eslint*"
+          # The name of the secret to fetch from Taskcluster's Secrets API
+          SSHKEY_SECRET_NAME: "github.com/biancadanforth/taskcluster-integration-poc/ssh-key"
+        command: # The command to run within the Docker image
           - "/bin/bash"
           - "-lc" # '--login' (executes user's profile commands), '-c' (executes commands from a string)
           - >-
@@ -52,7 +63,9 @@ tasks:
             npm run build &&
             npm run lint &&
             npm run package &&
-            /repo/bin/commit_xpi.sh
+            /repo/bin/commit_xpi.sh &&
+            /repo/bin/configure_ssh.sh &&
+            node /repo/bin/get_secret.js
       metadata:
         name: "Firefox Experiments GitHub Tests"
         description: "All tests"

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,116 +1,96 @@
-# References:
-#  - https://github.com/taskcluster/taskcluster-github/blob/master/.taskcluster.yml
-#  - https://github.com/taskcluster/taskcluster-github/blob/master/docs/taskcluster-yml-v1.md
+# Reference: https://github.com/taskcluster/taskcluster/blob/master/.taskcluster.yml
 version: 1
 policy:
-  # Run these tasks for qualifying GH events for collaborators only to avoid just anyone having
-  # access to my Taskcluster secret(s)
+  # Run these tasks for qualifying GH events for collaborators only to avoid just anyone
+  # having access to my Taskcluster secret(s)
   pullRequests: collaborators
 tasks:
-  # When a PR is opened, reopened or synchronized, perform this task; this covers additional
-  # commits to an existing open PR
-  - $if: 'tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "synchronize"]'
-    then:
-      # TC creates a task group with tasks in it; each task has an ID. TC will provide a link
-      # built with these IDs in GH's GUI every time a task is created, even if it fails.
-      taskId: {$eval: as_slugid("pr_task")} # Returns a hash of a string
-      created: {$fromNow: ''}
-      # If the task is not completed by its deadline, it will be resolved as `exception`
-      # with reason "deadline-exceeded"
-      deadline: {$fromNow: '1 hour'}
-      # Identifies the Taskcluster provisioner responsible for the compute resources
-      # (could be 1 CPU, a fraction of a CPU, multiple CPUs...)that will execute the
-      # task. e.g. 'aws-provisioner-v1' is the AWS Provisioner, which runs its tasks
-      # on Amazon EC2 instances using Docker.
-      provisionerId: aws-provisioner-v1
-      # A parameter specific to the AWS Provisioner which identifies the pool of EC2
-      # resources within which the task should be executed. Pools may use different
-      # EC2 instance types, AMIs (Amazon Machine Images), etc.
-      # Generally, github-worker is a variant of docker-worker in TC docs
-      workerType: github-worker # TC's generic worker for any github projects
-      # A scope is a permission to perform a particular action. A task has a set of scopes
-      # that determine what the task can do. These scopes are validated by the worker.
-      scopes:
-        - secrets:get:github.com/biancadanforth/taskcluster-integration-poc/ssh-key
-      payload: # format depends on workerType
-        features:
-          # Service provided by the worker that lets the task make authenticated TC
-          # requests within the scope(s) of a particular task.
-          taskclusterProxy: true
-        maxRunTime: 1200 # 20 minutes
-        image: "node:10" # The Docker image to pull
-        # The worker will automatically upload any artifacts upon task completion
-        artifacts: # format depends on the workerType
-          public/web-ext-artifacts:
-            # contentType is not a valid key for workerType github-worker
-            expires: {$fromNow: '14 days'}
-            path: /repo/web-ext-artifacts
-            type: directory
-        env: # Environment variables to declare in the shell
-          DEBUG: "* -eslint*" # Log levels for debug statements in library code; * means all
-          # The name of the secret to fetch from Taskcluster's Secrets API
-          SSHKEY_SECRET_NAME: "github.com/biancadanforth/taskcluster-integration-poc/ssh-key"
-          SHELL: "/bin/bash"
-        command: # The command to run within the Docker image
-          - "/bin/bash"
-          # '--login' (executes user's profile commands), '-c' (executes commands from a string)
-          - "-lc"
-          - >-
-            git clone ${event.pull_request.head.repo.git_url} repo &&
-            cd repo &&
-            git checkout ${event.pull_request.head.sha} &&
-            npm install &&
-            npm run build &&
-            npm run lint &&
-            npm run package &&
-            /repo/bin/configure_hg.sh &&
-            /repo/bin/commit_xpi.sh &&
-            /repo/bin/configure_ssh.sh &&
-            node /repo/bin/get_secret.js &&
-            cd mozilla-central &&
-            ./mach try -p linux64 -u all -t none --artifact
-      metadata:
-        name: "Firefox Experiments GitHub Tests"
-        description: "All tests"
-        owner: ${event.pull_request.user.login}@users.noreply.github.com
-        source: ${event.repository.url}
-  # When a commit is pushed to master, perform this task
-  # Note: Currently this is wrongly showing a status in GitHub PRs (Bug 1514914)
-  - $if: 'tasks_for == "github-push"'
-    then:
-      $if: 'event.ref == "refs/heads/master"'
+  $let:
+    # This only supports pushes and pull requests for now. If we start responding to another
+    # action type, make this a $match.
+    repo:
+      $if: 'tasks_for == "github-push"'
       then:
-        taskId: {$eval: as_slugid("push_task")}
+        git_url: ${event.repository.url}
+        url: ${event.repository.url}
+        ref: ${event.after}
+      else:
+        git_url: ${event.pull_request.head.repo.git_url}
+        url: ${event.pull_request.head.repo.url}
+        ref: ${event.pull_request.head.sha}
+  in:
+    $let:
+      taskRef:
+        # TC creates a task group with tasks in it; each task has an ID. TC will provide a link
+        # built with these IDs in GH's GUI every time a task is created, even if it fails.
+        taskId: {$eval: as_slugid("pr_task")} # Returns a hash of a string
         created: {$fromNow: ''}
+        # If the task is not completed by its deadline, it will be resolved as `exception`
+        # with reason "deadline-exceeded"
         deadline: {$fromNow: '1 hour'}
+        # Identifies the Taskcluster provisioner responsible for the compute resources
+        # (could be 1 CPU, a fraction of a CPU, multiple CPUs...)that will execute the
+        # task. e.g. 'aws-provisioner-v1' is the AWS Provisioner, which runs its tasks
+        # on Amazon EC2 instances using Docker.
         provisionerId: aws-provisioner-v1
-        workerType: github-worker
-        payload:
-          maxRunTime: 600
-          image: "node:8"
-          artifacts:
+        # A parameter specific to the AWS Provisioner which identifies the pool of EC2
+        # resources within which the task should be executed. Pools may use different
+        # EC2 instance types, AMIs (Amazon Machine Images), etc.
+        # Generally, github-worker is a variant of docker-worker in TC docs
+        workerType: github-worker # TC's generic worker for any github projects
+        # A scope is a permission to perform a particular action. A task has a set of scopes
+        # that determine what the task can do. These scopes are validated by the worker.
+        scopes:
+          - secrets:get:github.com/biancadanforth/taskcluster-integration-poc/ssh-key
+        payload: # format depends on workerType
+          features:
+            # Service provided by the worker that lets the task make authenticated TC
+            # requests within the scope(s) of a particular task.
+            taskclusterProxy: true
+          maxRunTime: 1200 # 20 minutes
+          image: "node:10" # The Docker image to pull
+          # The worker will automatically upload any artifacts upon task completion
+          artifacts: # format depends on the workerType
             public/web-ext-artifacts:
               # contentType is not a valid key for workerType github-worker
               expires: {$fromNow: '14 days'}
               path: /repo/web-ext-artifacts
               type: directory
-          env:
-            DEBUG: "* -eslint*"
-            NO_TEST_SKIP: "true"
-          command:
+          env: # Environment variables to declare in the shell
+            DEBUG: "* -eslint*" # Log levels for debug statements in library code; * means all
+            # The name of the secret to fetch from Taskcluster's Secrets API
+            SSHKEY_SECRET_NAME: "github.com/biancadanforth/taskcluster-integration-poc/ssh-key"
+            SHELL: "/bin/bash"
+          command: # The command to run within the Docker image
             - "/bin/bash"
+            # '--login' (executes user's profile commands), '-c' (executes commands from a string)
             - "-lc"
             - >-
-              git clone ${event.repository.url} repo &&
+              git clone ${repo.git_url} repo &&
               cd repo &&
-              git checkout ${event.after} &&
+              git checkout ${repo.ref} &&
               npm install &&
               npm run build &&
               npm run lint &&
               npm run package &&
-              /repo/bin/commit_xpi.sh
+              /repo/bin/configure_hg.sh &&
+              /repo/bin/commit_xpi.sh &&
+              /repo/bin/configure_ssh.sh &&
+              node /repo/bin/get_secret.js &&
+              cd mozilla-central &&
+              ./mach try -p linux64 -u all -t none --artifact
         metadata:
           name: "Firefox Experiments GitHub Tests"
           description: "All tests"
-          owner: ${event.pusher.name}@users.noreply.github.com
+          owner: ${event.pull_request.user.login}@users.noreply.github.com
           source: ${event.repository.url}
+    in:
+      # When a commit is pushed to master or a PR is opened, reopened or synchronized
+      - $if: 'tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "synchronize"]'
+        then: {$eval: taskRef}
+      # When a commit is pushed to master, perform this task
+      # Note: Currently this is wrongly showing a status in GitHub PRs (Bug 1514914)
+      - $if: 'tasks_for == "github-push"'
+        then:
+          $if: 'event.ref == "refs/heads/master"'
+          then: {$eval: taskRef}

--- a/bin/commit_xpi.sh
+++ b/bin/commit_xpi.sh
@@ -9,7 +9,7 @@
 set -e
 
 # Note: If clone fails with error: `abort: unexpected response from remote server: empty string.`,
-# that clonebundle may be corrupted. Try another URL to confirm and talk to sheehan in #vcs in IRC.
+# that clonebundle may be corrupted. Try another URL to confirm and contact #vcs in IRC.
 echo ">>> Clone Firefox"
 hg clone https://hg.mozilla.org/mozilla-central
 

--- a/bin/commit_xpi.sh
+++ b/bin/commit_xpi.sh
@@ -27,4 +27,4 @@ cp /repo/web-ext-artifacts/* /repo/mozilla-central/testing/profiles/common/exten
 echo ">>> Commit diff to hg"
 cd mozilla-central
 hg add .
-hg commit -u "Bianca Danforth <bdanforth@mozilla.com>" -m "Temporary commit to run extension on the Try server"
+hg commit -m "Temporary commit to run extension on the Try server"

--- a/bin/commit_xpi.sh
+++ b/bin/commit_xpi.sh
@@ -25,3 +25,6 @@ cp /repo/web-ext-artifacts/* /repo/mozilla-central/testing/profiles/common/exten
 
 # The diff needs to be checked in to run on the Try server
 echo ">>> Commit diff to hg"
+cd mozilla-central
+hg add .
+hg commit -u "Bianca Danforth <bdanforth@mozilla.com>" -m "Temporary commit to run extension on the Try server"

--- a/bin/commit_xpi.sh
+++ b/bin/commit_xpi.sh
@@ -8,39 +8,20 @@
 
 set -e
 
-# TODO: Make env variable in .taskcluster.yml that gets passed to this script to specify
-# which channel(s) to test in
-
-# Repo URLs:
-#   - Nightly: https://hg.mozilla.org/mozilla-central
-#   - Beta: https://hg.mozilla.org/releases/mozilla-beta
-#   - Release: https://hg.mozilla.org/releases/mozilla-release
-echo ">>> clone Firefox"
-# TODO: Investigate how to get a shallow clone of Firefox -- this full clone takes 3ish minutes alone.
+# Note: If clone fails with error: `abort: unexpected response from remote server: empty string.`,
+# that clonebundle may be corrupted. Try another URL to confirm and talk to sheehan in #vcs in IRC.
+echo ">>> Clone Firefox"
 hg clone https://hg.mozilla.org/mozilla-central
 
-# Test dir(s) specified per bugs 1451159 and 1458571
-echo ">>> copy XPI (or ZIP) to test dir"
+# Per bugs 1451159/1458571, when copied here, the extension will be installed with the testing profile.
+echo ">>> Copy XPI (or ZIP) to test dir"
 cp /repo/web-ext-artifacts/* /repo/mozilla-central/testing/profiles/common/extensions/
 
-# --artifact is not a recognized option for './mach build', so enable artifact builds via .mozconfig
-echo ">>> copy over .mozconfig to enable artifact builds locally"
-# TODO: make .mozconfig file
-# TODO: For Beta and Release builds, add 'releases/mozilla-beta' or 'releases/mozilla-release'
-# respectively to the list of CANDIDATE_TREES in ./python/mozbuild/mozbuild/artifacts.py
-
-echo ">>> copy test files over to Firefox"
-# TODO: copy contents of repo/test/ into Firefox's ./testing/extensions/ dir. 
-
-echo ">>> build Firefox"
-# ./mach clobber
-# ./mach build
-
-# The diff does NOT need to be checked in to run tests locally
-# Note: The extension is only installed with the testing profile (i.e. when running mochitests or talos
-# tests); it is not installed with ./mach build or ./mach run separately.
-echo ">>> verify with local mochitest that extension is installed"
-# ./mach test /path/to/test
+# TODO - depends on Bug 1517083, else must edit an existing moz.build file programmatically ~
+# echo ">>> Copy over .mozconfig to enable artifact builds locally"
+# echo ">>> Copy test files over to Firefox"
+# echo ">>> Build Firefox"
+# echo ">>> Verify with custom local mochitest that extension is installed"
 
 # The diff needs to be checked in to run on the Try server
-echo ">>> commit diff to hg"
+echo ">>> Commit diff to hg"

--- a/bin/configure_hg.sh
+++ b/bin/configure_hg.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Clone the version-control-tools hg repo so that the push-to-try extension is
+# installed in hg via hg's global config file, ~/.hgrc.
+# This extension is required for pushing to the Try server; firefoxtree is recommended.
+
+set -e
+
+# This repo has the requisite extension `push-to-try` and the recommended extension firefoxtree
+# Reference: https://wiki.mozilla.org/ReleaseEngineering/TryServer, Configuration section
+echo ">>> Clone Mozilla Version Control Tools hg repo"
+cd ~
+hg clone https://hg.mozilla.org/hgcustom/version-control-tools/
+
+# Let hg know where to find these extensions
+echo ">>> Create .hgrc file to enable firefoxtree and push-to-try extensions"
+if [ ! -f ~/.hgrc ]
+then
+   cat <<EOF > ~/.hgrc
+[ui]
+username = Bianca Danforth <bdanforth@mozilla.com>
+[extensions]
+firefoxtree = /root/version-control-tools/hgext/firefoxtree
+push-to-try = /root/version-control-tools/hgext/push-to-try
+EOF
+fi

--- a/bin/configure_hg.sh
+++ b/bin/configure_hg.sh
@@ -10,6 +10,14 @@
 
 set -e
 
+# Update version of Mercurial
+apt-get remove -y mercurial # system package managers often lag behind compared to others like pip
+apt autoremove -y libjs-excanvas mercurial-common # remove related automatically installed packages
+apt update
+apt install -y python-pip
+pip install mercurial
+hash hg # clear old location of hg in bash's cache
+
 # This repo has the requisite extension `push-to-try` and the recommended extension firefoxtree
 # Reference: https://wiki.mozilla.org/ReleaseEngineering/TryServer, Configuration section
 echo ">>> Clone Mozilla Version Control Tools hg repo"

--- a/bin/configure_hg.sh
+++ b/bin/configure_hg.sh
@@ -11,7 +11,7 @@
 set -e
 
 # Update version of Mercurial
-apt-get remove -y mercurial # system package managers often lag behind compared to others like pip
+apt remove -y mercurial # system package managers often lag behind compared to others like pip
 apt autoremove -y libjs-excanvas mercurial-common # remove related automatically installed packages
 apt update
 apt install -y python-pip

--- a/bin/configure_hg.sh
+++ b/bin/configure_hg.sh
@@ -30,7 +30,7 @@ if [ ! -f ~/.hgrc ]
 then
    cat <<EOF > ~/.hgrc
 [ui]
-username = Bianca Danforth <bdanforth@mozilla.com>
+username = $USERNAME <$USER_EMAIL>
 [extensions]
 firefoxtree = /root/version-control-tools/hgext/firefoxtree
 push-to-try = /root/version-control-tools/hgext/push-to-try

--- a/bin/configure_ssh.sh
+++ b/bin/configure_ssh.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Makes a .ssh dir if one does not exist and adds a $HOME/.ssh/config file.
+# The secret fetched from Taskcluster is a private SSH key. It will be
+# stored in $HOME/.ssh/id_rsa_experiments_pusher (see ./bin/get_secret.js)
+# and that file is pointed at by the $HOME/.ssh/config file. Once we have
+# this key and SSH config set up, we can push to the Try server!
+
+set -e
+
+echo ">>> Make the $HOME/.ssh dir if it doesn't exist"
+cd ~
+if [ ! -d .ssh ]
+then
+  mkdir .ssh
+fi
+
+echo ">>> Set up SSH config with Experiments Pusher user"
+if [ ! -f ~/.ssh/config ]
+then
+  cat <<EOF > ~/.ssh/config
+Host hg.mozilla.org
+  User experiments-pusher@mozilla.com
+  # for experiments try server pushing
+  IdentityFile ~/.ssh/id_rsa_experiments_pusher
+EOF
+fi

--- a/bin/configure_ssh.sh
+++ b/bin/configure_ssh.sh
@@ -31,7 +31,7 @@ EOF
 fi
 
 # Without this, the first time I connect to this server, it will prompt me
-# to ask if I am sure I want to connect. and the task will hang and timeout.
+# to ask if I am sure I want to connect, and the task will hang and timeout.
 echo ">>> Put hg.mozilla.org server on the list of known hosts"
 if [ ! -f ~/.ssh/known_hosts ]
 then

--- a/bin/configure_ssh.sh
+++ b/bin/configure_ssh.sh
@@ -30,11 +30,13 @@ Host hg.mozilla.org
 EOF
 fi
 
-# Without this, the first time I connect to this server, it will prompt me
-# to ask if I am sure I want to connect, and the task will hang and timeout.
+# Without this, the first time I connect to this server, it will prompt me to ask
+# if I am sure I want to connect, and the task will hang and timeout. This public
+# key for hg.mozilla.org is taken out-of-band from my own ~/.ssh/known_hosts file.
 echo ">>> Put hg.mozilla.org server on the list of known hosts"
 if [ ! -f ~/.ssh/known_hosts ]
 then
-   touch ~/.ssh/known_hosts
-   ssh-keyscan -t rsa -H hg.mozilla.org >> ~/.ssh/known_hosts
+  cat <<EOF > ~/.ssh/known_hosts
+hg.mozilla.org,63.245.215.25 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGuRsL+/OrvIekv3iBST1zdVBLBuh/DMIj+ZN72N9a0g
+EOF
 fi

--- a/bin/configure_ssh.sh
+++ b/bin/configure_ssh.sh
@@ -29,3 +29,12 @@ Host hg.mozilla.org
   IdentityFile ~/.ssh/id_rsa_experiments_pusher
 EOF
 fi
+
+# Without this, the first time I connect to this server, it will prompt me
+# to ask if I am sure I want to connect. and the task will hang and timeout.
+echo ">>> Put hg.mozilla.org server on the list of known hosts"
+if [ ! -f ~/.ssh/known_hosts ]
+then
+   touch ~/.ssh/known_hosts
+   ssh-keyscan -t rsa -H hg.mozilla.org >> ~/.ssh/known_hosts
+fi

--- a/bin/get_secret.js
+++ b/bin/get_secret.js
@@ -7,6 +7,7 @@ const taskcluster = require("taskcluster-client");
 const fs = require("fs");
 
 const SSHKEY_SECRET_NAME = process.env.SSHKEY_SECRET_NAME || "";
+const IDENTITY_FILE = `${process.env.HOME}/.ssh/id_rsa_experiments_pusher`;
 
 (async function main() {
   if (SSHKEY_SECRET_NAME) {
@@ -14,10 +15,10 @@ const SSHKEY_SECRET_NAME = process.env.SSHKEY_SECRET_NAME || "";
     const sshKeySecret = await secrets.get(SSHKEY_SECRET_NAME);
     const sshKey = sshKeySecret.secret["ssh-key"] || null;
     if (sshKey) {
-      fs.writeFile(`${process.env.HOME}/.ssh/id_rsa_experiments_pusher`, sshKey, "utf8", (err) => {
+      fs.writeFile(IDENTITY_FILE, sshKey, "utf8", (err) => {
         if (err) console.log(err);
         // Try server rejects if identity file permissions are too open; restrict to read by owner only
-        fs.chmod(`${process.env.HOME}/.ssh/id_rsa_experiments_pusher`, fs.constants.S_IRUSR, (err) => {
+        fs.chmod(IDENTITY_FILE, fs.constants.S_IRUSR, (err) => {
           if (err) console.log(err);
         });
       });

--- a/bin/get_secret.js
+++ b/bin/get_secret.js
@@ -16,7 +16,10 @@ const SSHKEY_SECRET_NAME = process.env.SSHKEY_SECRET_NAME || "";
     if (sshKey) {
       fs.writeFile(`${process.env.HOME}/.ssh/id_rsa_experiments_pusher`, sshKey, "utf8", (err) => {
         if (err) console.log(err);
-        console.log(typeof sshKey);
+        // Try server rejects if identity file permissions are too open; restrict to read by owner only
+        fs.chmod(`${process.env.HOME}/.ssh/id_rsa_experiments_pusher`, fs.constants.S_IRUSR, (err) => {
+          if (err) console.log(err);
+        });
       });
     }
   }

--- a/bin/get_secret.js
+++ b/bin/get_secret.js
@@ -17,7 +17,7 @@ const IDENTITY_FILE = `${process.env.HOME}/.ssh/id_rsa_experiments_pusher`;
     if (sshKey) {
       fs.writeFile(IDENTITY_FILE, sshKey, "utf8", (err) => {
         if (err) console.log(err);
-        // Try server rejects if identity file permissions are too open; restrict to read by owner only
+        // ssh client rejects if identity file permissions are too open; restrict to read by owner only
         fs.chmod(IDENTITY_FILE, fs.constants.S_IRUSR, (err) => {
           if (err) console.log(err);
         });

--- a/bin/get_secret.js
+++ b/bin/get_secret.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+const taskcluster = require("taskcluster-client");
+const fs = require("fs");
+
+const SSHKEY_SECRET_NAME = process.env.SSHKEY_SECRET_NAME || "";
+
+(async function main() {
+  if (SSHKEY_SECRET_NAME) {
+    const secrets = new taskcluster.Secrets({rootUrl: "http://taskcluster"});
+    const sshKeySecret = await secrets.get(SSHKEY_SECRET_NAME);
+    const sshKey = sshKeySecret.secret["ssh-key"] || null;
+    if (sshKey) {
+      fs.writeFile(`${process.env.HOME}/.ssh/id_rsa_experiments_pusher`, sshKey, "utf8", (err) => {
+        if (err) console.log(err);
+        console.log(typeof sshKey);
+      });
+    }
+  }
+}());

--- a/package-lock.json
+++ b/package-lock.json
@@ -667,6 +667,52 @@
         "json-merge-patch": "^0.2.3"
       }
     },
+    "amqplib": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.5.3.tgz",
+      "integrity": "sha512-ZOdUhMxcF+u62rPI+hMtU1NBXSDFQ3eCJJrenamtdQ7YYwh7RZJHOIM1gonVbZ5PyVdYH4xqBPje9OYqk7fnqw==",
+      "dev": true,
+      "requires": {
+        "bitsyntax": "~0.1.0",
+        "bluebird": "^3.5.2",
+        "buffer-more-ints": "~1.0.0",
+        "readable-stream": "1.x >=1.1.9",
+        "safe-buffer": "~5.1.2",
+        "url-parse": "~1.4.3"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+          "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -1179,6 +1225,17 @@
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
       "dev": true
     },
+    "bitsyntax": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bitsyntax/-/bitsyntax-0.1.0.tgz",
+      "integrity": "sha512-ikAdCnrloKmFOugAfxWws89/fPc+nw0OOG1IzIE72uSOg/A3cYptKCjSUhDTuj7fhsJtzkzlv7l3b8PzRHLN0Q==",
+      "dev": true,
+      "requires": {
+        "buffer-more-ints": "~1.0.0",
+        "debug": "~2.6.9",
+        "safe-buffer": "~5.1.2"
+      }
+    },
     "bl": {
       "version": "1.2.2",
       "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -1232,6 +1289,15 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "dev": true,
+      "requires": {
+        "hoek": "4.x.x"
+      }
     },
     "boxen": {
       "version": "1.3.0",
@@ -1412,6 +1478,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "buffer-more-ints": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
       "dev": true
     },
     "buffer-xor": {
@@ -1906,6 +1978,12 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+      "dev": true
+    },
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -2129,6 +2207,26 @@
       "resolved": "https://registry.npmjs.org/crx-parser/-/crx-parser-0.1.2.tgz",
       "integrity": "sha1-fu7tnt3JXiLBiTguNGJARKiaWm0=",
       "dev": true
+    },
+    "cryptiles": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.4.tgz",
+      "integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
+      "dev": true,
+      "requires": {
+        "boom": "5.x.x"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "dev": true,
+          "requires": {
+            "hoek": "4.x.x"
+          }
+        }
+      }
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -4078,6 +4176,12 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
+      "dev": true
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -5190,6 +5294,18 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "dev": true,
+      "requires": {
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -5200,6 +5316,12 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+      "dev": true
     },
     "home-or-tmp": {
       "version": "3.0.0",
@@ -6424,6 +6546,12 @@
         }
       }
     },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -6462,6 +6590,12 @@
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
       }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.37.0",
@@ -7786,6 +7920,12 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
+    "querystringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
+      "dev": true
+    },
     "quick-format-unescaped": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.1.tgz",
@@ -8144,6 +8284,12 @@
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
       }
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
     },
     "resolve": {
       "version": "1.8.1",
@@ -8624,6 +8770,23 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "slugid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/slugid/-/slugid-1.1.0.tgz",
+      "integrity": "sha1-4J8AiZwJ9acFjtw23UnwRv1QqCo=",
+      "dev": true,
+      "requires": {
+        "uuid": "^2.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+          "dev": true
+        }
+      }
+    },
     "smart-buffer": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
@@ -8736,6 +8899,15 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
+      }
+    },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "dev": true,
+      "requires": {
+        "hoek": "4.x.x"
       }
     },
     "snyk": {
@@ -9635,6 +9807,65 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -9722,6 +9953,54 @@
           }
         }
       }
+    },
+    "taskcluster-client": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/taskcluster-client/-/taskcluster-client-12.2.0.tgz",
+      "integrity": "sha512-2Fu5ICS2663kC2t8ymJYzRDnipj3DsCK//b+H/83RjJvC6cWZ0akKzq0ySvPlNA6ic2UcL4I03bJTCJYBX1dqg==",
+      "dev": true,
+      "requires": {
+        "amqplib": "^0.5.1",
+        "debug": "^3.1.0",
+        "hawk": "^6.0.2",
+        "lodash": "^4.17.4",
+        "promise": "^8.0.1",
+        "slugid": "^1.1.0",
+        "superagent": "~3.8.1",
+        "taskcluster-lib-urls": "^10.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "promise": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.2.tgz",
+          "integrity": "sha512-EIyzM39FpVOMbqgzEHhxdrEhtOSDOtjMZQ0M6iVfCE+kWNgCkAyOdnuCWqfmflylftfadU6FkiMgHZA2kUzwRw==",
+          "dev": true,
+          "requires": {
+            "asap": "~2.0.6"
+          }
+        }
+      }
+    },
+    "taskcluster-lib-urls": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/taskcluster-lib-urls/-/taskcluster-lib-urls-10.1.1.tgz",
+      "integrity": "sha512-tdrK++rCX73FMXk/cXwS6RLTjA3pX8hJlxg1ECLs3L3llCOPMNhQ4wi6lb6yMgHc/s5on/Edj6AlAH7gkxzgPg==",
+      "dev": true
     },
     "temp-dir": {
       "version": "1.0.0",
@@ -10321,6 +10600,16 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
+      }
+    },
+    "url-parse": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "url-parse-lax": {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "eslint-plugin-mozilla": "1.0.3",
     "eslint-plugin-no-unsanitized": "^3.0.2",
     "generate-json-webpack-plugin": "0.3.1",
+    "taskcluster-client": "12.2.0",
     "web-ext": "2.9.2",
     "webpack": "4.27.1",
     "webpack-cli": "3.1.2"
-  },
-  "dependencies": {}
+  }
 }


### PR DESCRIPTION
Make an authenticated request to the Taskcluster Secrets API to fetch the secret containing the private SSH key for the Experiments machine account which has scm_level_1 access to push to the Try server. See [Bug 1512569](https://bugzilla.mozilla.org/show_bug.cgi?id=1512569) where that account is created.

For this to work, there are many prerequisites:
1. A Taskcluster admin must grant permissions to the developer, in my case:
* `assume:github-admin:biancadanforth/*`
  * to create/edit roles for github repos under my username
* `secrets:get:github.com/biancadanforth/*`
  * To read secrets under this domain
* `secrets:set:github.com/biancadanforth/*`
  * To write secrets under this domain
2. Create a new secret (called `github.com/biancadanforth/taskcluster-integration-poc/ssh-key` to follow [secret naming conventions](https://docs.taskcluster.net/docs/manual/design/namespaces#secrets)) using Taskcluster’s [Secret Manager](https://tools.taskcluster.net/secrets) that represents your private SSH key for your machine account created in [Bug 1512569](https://bugzilla.mozilla.org/show_bug.cgi?id=1512569).
3. Create a new role with a new scope in the [Role Manager](https://tools.taskcluster.net/auth/roles/) that allows me to read the secret created in Step 2 from Taskcluster’s Secrets API.
* Role: `repo:github.com/biancadanforth/taskcluster-integration-poc:pull-request`
* Description: Allows tasks to read the github.com/biancadanforth/taskcluster-integration-poc/ssh-key secret, which contains the private SSH key for the Experiments machine account to push to the Try server via Taskcluster (see https://bugzilla.mozilla.org/show_bug.cgi?id=1512569).
* Scope: `secrets:get:github.com/biancadanforth/taskcluster-integration-poc/ssh-key`
4. Add the scope from Step 3 to the `.taskcluster.yml` config file under `task.scopes`.
* Also add the `[payload.features.taskclusterProxy](https://docs.taskcluster.net/docs/reference/workers/docker-worker/docs/features#feature-taskclusterproxy)` key with a value of `true`. This service allows us to make authenticated requests to Taskcluster (for example, to fetch our secret).
* Also set `policy.pullRequests` to `collaborators`. This ensures only collaborators have access to my Taskcluster secret(s).