### PR TITLE
Fix #8: Run custom mochitest locally and on Try server

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -82,7 +82,7 @@ tasks:
               /repo/bin/configure_ssh.sh &&
               node /repo/bin/get_secret.js &&
               cd mozilla-central &&
-              ./mach try -p linux64 -u all -t none --artifact
+              ./mach try -b o -p linux64 testing/extensions --artifact
         metadata:
           name: "Firefox Experiments GitHub Tests"
           description: "All tests"

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ This project demonstrates the following capabilities using Taskcluster:
 * Run extension-specific tests in Node
 * Upload extension's XPI as a build artifact
 * Run regression tests on the Try server with the extension installed
-
-This is largely done through the [Taskcluster config file](.taskcluster.yml) in the project's root directory.
+* Allow developers to run custom Mozilla tests on the Try server (See [Issue #8](https://github.com/biancadanforth/taskcluster-integration-poc/issues/8))
 
 
 
@@ -19,7 +18,6 @@ This is largely done through the [Taskcluster config file](.taskcluster.yml) in 
 
 In addition to the capabilities listed above, ultimately, this project will also:
 * Provide a baseline Taskcluster config that developers can drop into their existing GitHub repositories
-* Allow developers to run custom Mozilla tests on the Try server (See [Issue #8](https://github.com/biancadanforth/taskcluster-integration-poc/issues/8))
 * Suggest the minimum set of Mozilla tests to run and when (See [Issue #14](https://github.com/biancadanforth/taskcluster-integration-poc/issues/14))
 
 
@@ -76,7 +74,15 @@ npm run lint
 
 #### Testing on the Try server
 
-To run existing Mozilla tests in Firefox on the Try server, open a PR. Taskcluster will start up a task to do this automatically.
+_To run custom and/or existing Mozilla tests in Firefox on the Try server_
+1. Add the desired Try syntax to the `./mach try` command in the [Taskcluster config file](.taskcluster.yml); for example:
+  - To run existing page load performance tests, you can use `./mach try fuzzy -q 'linux64 raptor-tp6 firefox'`.
+  - To run the custom Mochitest provided in this example repo, you can use `./mach try -b o -p linux64 testing/extensions --artifact`.
+2. Open a PR.
+
+Note: Once [Issue #19](https://github.com/biancadanforth/taskcluster-integration-poc/issues/19) is closed, a single `./mach try` command can run the custom tests and performance tests.
+
+Taskcluster will start up a task to run the tests automatically.
 
 The task's status can be viewed in the PR in GitHub. Task details, logs and build artifacts can be found in the [Taskcluster dashboard](#the-taskcluster-dashboard).
 

--- a/bin/commit_xpi.sh
+++ b/bin/commit_xpi.sh
@@ -4,27 +4,40 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# Clones Firefox, copies the XPI to a test directory and commits the change to Mercurial.
+# Clones Firefox, copies the XPI and any custom tests to testing directories
+# and commits the change to Mercurial.
 
 set -e
 
-# Note: If clone fails with error: `abort: unexpected response from remote server: empty string.`,
-# that clonebundle may be corrupted. Try another URL to confirm and contact #vcs in IRC.
+# Note: If clone fails with error: `abort: unexpected response from remote
+# server: empty string.`, that clonebundle may be corrupted. Try another URL
+# to confirm and contact #vcs in IRC.
 echo ">>> Clone Firefox"
 hg clone https://hg.mozilla.org/mozilla-central
 
-# Per bugs 1451159/1458571, when copied here, the extension will be installed with the testing profile.
+# Per bugs 1451159/1458571, when copied here, the extension will be installed
+# with the testing profile.
 echo ">>> Copy XPI (or ZIP) to test dir"
 cp /repo/web-ext-artifacts/* /repo/mozilla-central/testing/profiles/common/extensions/
 
-# TODO - depends on Bug 1517083, else must edit an existing moz.build file programmatically ~
-# echo ">>> Copy over .mozconfig to enable artifact builds locally"
-# echo ">>> Copy test files over to Firefox"
-# echo ">>> Build Firefox"
-# echo ">>> Verify with custom local mochitest that extension is installed"
+# Run custom mochitest on Docker image before pushing to Try (See bug 1517083)
+echo ">>> Create .mozconfig to enable artifact builds locally"
+if [ ! -f /repo/mozilla-central/.mozconfig ]
+then
+  cat <<EOF > /repo/mozilla-central/.mozconfig
+# Automatically download and use compiled C++ components:
+ac_add_options --enable-artifact-builds
+EOF
+fi
+echo ">>> Copy test files over to Firefox"
+cp -r /repo/test/* /repo/mozilla-central/testing/extensions/
+echo ">>> Build Firefox"
+cd mozilla-central
+./mach build
+echo ">>> Verify with custom local mochitest that extension is installed"
+./mach test testing/extensions
 
 # The diff needs to be checked in to run on the Try server
 echo ">>> Commit diff to hg"
-cd mozilla-central
 hg add .
 hg commit -m "Temporary commit to run extension on the Try server"

--- a/bin/commit_xpi.sh
+++ b/bin/commit_xpi.sh
@@ -31,8 +31,10 @@ EOF
 fi
 echo ">>> Copy test files over to Firefox"
 cp -r /repo/test/* /repo/mozilla-central/testing/extensions/
-echo ">>> Build Firefox"
+echo ">>> Run ./mach bootstrap to install dependencies for building Firefox"
 cd mozilla-central
+echo 1 | ./mach bootstrap --no-interactive # see Bug 1521903
+echo ">>> Build Firefox"
 ./mach build
 echo ">>> Verify with custom local mochitest that extension is installed"
 ./mach test testing/extensions

--- a/bin/commit_xpi.sh
+++ b/bin/commit_xpi.sh
@@ -36,6 +36,12 @@ cd mozilla-central
 echo 1 | ./mach bootstrap --no-interactive # see Bug 1521903
 echo ">>> Build Firefox"
 ./mach build
+# Mochitests require a display, so we must run the tests headlessly
+echo ">>> Start up a display server so mochitests can run"
+apt install xvfb -y
+Xvfb :99 &
+export DISPLAY=:99
+
 echo ">>> Verify with custom local mochitest that extension is installed"
 ./mach test testing/extensions
 


### PR DESCRIPTION
Runs the custom mochitest, `browser_experiment_installed_check.js`, which simply checks if the add-on is installed in Firefox.

It is possible to do this thanks to Bug 1517083, which just landed, which has the build system look in a new ./testing/extensions/ directory for tests to run.